### PR TITLE
Local setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ app/json/*
 fastify/node_modules
 pocketbase/*
 helper.txt
+env/*

--- a/README.md
+++ b/README.md
@@ -26,7 +26,36 @@ Built with:
 - [Redis](https://redis.io/): Caching Data
 
 # Getting started
-Coming soon to run stocknear locally on your machine.
+Follow the instructions below to run stocknear locally on your machine.
+
+## Prerequisites & Resources
+
+* Python 3.x (Recommended: 3.10.12 or higher)
+* Pip (Python package installer)
+* PocketBase (Download and install from: https://pocketbase.io/
+
+* Download schemas, databases and configurations files:
+  * stocks.db [TODO - add link] 
+  * crypto.db [TODO - add link]
+  * institute.db [TODO - add link]
+  * json.zip folder [TODO - add link]
+  * pocketbase schema [TODO - add link]
+
+## Installation
+
+1. **Set up virtual env:**
+
+`python -m venv env`
+`source env/bin/activate`  # On macOS/Linux
+`.\env\Scripts\activate`   # On Windows
+
+2. **Install dependencies:**
+
+`pip install -r requirements.txt`
+
+## Run
+
+`python .\app\main.py`
 
 # Contributing
 Stocknear is open-source software and you're welcome to contribute to its development.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Follow the instructions below to run stocknear locally on your machine.
 1. **Set up virtual env:**
 
 `python -m venv env`
+
 `source env/bin/activate`  # On macOS/Linux
+
 `.\env\Scripts\activate`   # On Windows
 
 2. **Install dependencies:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 benzinga
+urllib3==1.26.18
 yfinance
 datetime
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+benzinga
 yfinance
 datetime
 pandas


### PR DESCRIPTION
Updated README to provide some local setup instructions.
Set urllib3 dependency to 1.26.18 to address benzinga <-> requests conflict. We should remember about the technical debt this PR introduces.